### PR TITLE
Add support for n-ui

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -34,6 +34,12 @@
       "rangeStrategy": "pin"
     },
     {
+      "packageNames": [
+        "@financial-times/n-ui"
+      ],
+      "rangeStrategy": "replace"
+    },
+    {
       "depTypeList": [
         "devDependencies"
       ],


### PR DESCRIPTION
This prevents version pinning for the `@financial-times/n-ui` package.

The package has its own release process that depends on a ranged version.

On a major release, Renovate should still open a pull requests for us.