### PR TITLE
Origami support

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -26,7 +26,7 @@
   "packageRules": [
     {
       "packagePatterns": [
-        "@financial-times"
+        "^@financial-times"
       ],
       "depTypeList": [
         "dependencies"
@@ -42,6 +42,12 @@
     {
       "depTypeList": [
         "devDependencies"
+      ],
+      "masterIssueApproval": true
+    },
+    {
+      "packagePatterns": [
+        "^o-"
       ],
       "masterIssueApproval": true
     }


### PR DESCRIPTION
We should ignore Origami components included as dependencies.

These packages need to match the same version as in bower.json.

Save the pending change in the Renovate master issue so we're at least aware there's a new version out.

Closes https://github.com/Financial-Times/next/issues/214.