### PR TITLE
Set a branch prefix

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -21,6 +21,7 @@
   "labels": [
     "dependencies"
   ],
+  "branchPrefix": "renovate-",
   "rangeStrategy": "replace",
   "masterIssue": true,
   "packageRules": [


### PR DESCRIPTION
The default prefix is `renovate/`.

We should avoid slashes in the branch name, as a limitation of git means we then shouldn't use `renovate` as a branch name.

See https://github.com/renovatebot/config-help/issues/108#issuecomment-430576178 for more information.