### PR TITLE
Extend package pinning

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -26,7 +26,17 @@
   "packageRules": [
     {
       "packagePatterns": [
-        "^@financial-times"
+        "^@financial-times",
+        "^ft-next-",
+        "^ft-n-",
+        "^n-",
+        "^next-",
+        "^s3o-"
+      ],
+      "packageNames": [
+        "shellpromise",
+        "fetchres",
+        "isomorphic-fetch"
       ],
       "depTypeList": [
         "dependencies"


### PR DESCRIPTION
Include a number of FT specific package naming conventions.

While `^@financial-times` will cover most, this just extends our reach a little more.