### PR TITLE
Change `rangeStrategy` to 'auto' for FT packages

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -41,7 +41,7 @@
       "depTypeList": [
         "dependencies"
       ],
-      "rangeStrategy": "pin"
+      "rangeStrategy": "auto"
     },
     {
       "packageNames": [


### PR DESCRIPTION
We're going to trust Renovate to do the right thing i.e. `pin` these dependencies for apps and `widen` or `replace` them for libraries.

See: https://renovatebot.com/docs/configuration-options/#rangestrategy