### PR TITLE
Increase the hourly PR rate limit

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -10,7 +10,7 @@
     ":automergeDisabled",
     ":ignoreModulesAndTests",
     ":maintainLockFilesDisabled",
-    ":prHourlyLimit2",
+    ":prHourlyLimit4",
     ":prConcurrentLimit20",
     "group:monorepos",
     "group:recommended",


### PR DESCRIPTION
From 2 an hour to 4.

We are hitting the rate limit quickly when onboarding Renovate with new projects.