### PR TITLE
Ignore the bower package

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -64,5 +64,8 @@
       ],
       "masterIssueApproval": true
     }
+  ],
+  "ignoreDeps": [
+    "bower"
   ]
 }


### PR DESCRIPTION
See https://renovatebot.com/docs/configuration-options/#ignoredeps for more information on ignoring dependencies.

We are ignoring bower to prevent Renovate from creating deprecation warning issues for every repository that depends on @financial-times/n-ui.