### PR TITLE
Ignore upgrades to node

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -66,6 +66,7 @@
     }
   ],
   "ignoreDeps": [
-    "bower"
+    "bower",
+    "node"
   ]
 }


### PR DESCRIPTION
Because of issues in Node 8.14, we do not want to raise pull requests for upgrading the version of node in our projects.

We will deal with upgrades as part of a transformation across all repositories.

This is only until we are happy that our systems are stable on the latest versions of node again.

Resolves https://github.com/Financial-Times/next/issues/280.

Relates to the header limit issues we are currently seeing, https://github.com/Financial-Times/next-bugs/issues/222.