### PR TITLE
Group x-dash packages as a mono-repository

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -63,6 +63,13 @@
         "^o-"
       ],
       "masterIssueApproval": true
+    },
+    {
+      "packagePatterns": [
+        "^@financial-times/x-"
+      ],
+      "groupName": "x-dash monorepo",
+      "groupSlug": "x-dash"
     }
   ],
   "ignoreDeps": [


### PR DESCRIPTION
Assumes that all x-dash packages are prefixed with a package name of `@financial-times/x-`.

See https://renovatebot.com/docs/noise-reduction/#package-grouping for more information.

Resolves #19.