### PR TITLE
Update the CircleCI configuration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,3 +8,9 @@ jobs:
       - checkout
       - run: npm install
       - run: npm test
+
+workflows:
+  version: 2
+  build:
+    jobs:
+      - build


### PR DESCRIPTION
When using the CircleCI Checks GitHub App, our builds should actually define a workflow in their configuration.

This will then cause CircleCI to only report on the status of a PR at a workflow level rather than as it does currently at the individual job level, which gets verbose quickly.

See https://circleci.com/docs/2.0/enable-checks/#prerequisites for more information.