### PR TITLE
Enable Renovate to manage node versions

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,7 @@
 {
   "extends": [
-    ":onlyNpm",
+    ":npm",
+    ":docker",
     ":separateMajorReleases",
     ":combinePatchMinorReleases",
     ":ignoreUnstable",
@@ -19,6 +20,9 @@
   ],
   "labels": [
     "dependencies"
+  ],
+  "supportPolicy": [
+    "lts"
   ],
   "branchPrefix": "renovate-",
   "rangeStrategy": "replace",
@@ -73,7 +77,6 @@
     }
   ],
   "ignoreDeps": [
-    "bower",
-    "node"
+    "bower"
   ]
 }


### PR DESCRIPTION
We would like Renovate to open pull requests on our repositories when there are new versions of node available.

There are several files in our repository that will need changing...

* `.nvmrc`
* `.circleci/config.yml`
* `package.json`

We have already pinned the version of node used in all of our apps. With Renovate opening pull requests to upgrade node, we can release upgrades in isolation to code changes.

Resolves #26. 