### PR TITLE
Enable Renovate to manage node versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ We have a custom set of rules for FT.com repositories. We are generally...
 
 * Grouping updates for our monorepos (such as [x-dash](https://github.com/Financial-Times/x-dash) and [anvil](https://github.com/Financial-Times/anvil)) into a single pull request
 
+* [Upgrading Node.js to LTS versions](https://renovatebot.com/docs/node/#configuring-support-policy), including any under their maintenance period.
+
 * Tracking major updates of `devDependencies` and [Origami](https://registry.origami.ft.com/components) components (`o-*` packages) in the Renovate master issue, but **we're not** opening pull requests automatically for them
 
 Read more about [how we're using Renovate on it's wiki page](https://github.com/Financial-Times/next/wiki/Renovate).

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,7 @@
 {
   "extends": [
-    ":onlyNpm",
+    ":npm",
+    ":docker",
     ":separateMajorReleases",
     ":combinePatchMinorReleases",
     ":ignoreUnstable",
@@ -19,6 +20,9 @@
   ],
   "labels": [
     "dependencies"
+  ],
+  "supportPolicy": [
+    "lts"
   ],
   "branchPrefix": "renovate-",
   "rangeStrategy": "replace",
@@ -73,7 +77,6 @@
     }
   ],
   "ignoreDeps": [
-    "bower",
-    "node"
+    "bower"
   ]
 }


### PR DESCRIPTION
We would like Renovate to open pull requests on our repositories when there are new versions of node available.

There are several files in our repository that will need changing...

* `.nvmrc`
* `.circleci/config.yml`
* `package.json`

We have already pinned the version of node used in all of our apps. With Renovate opening pull requests to upgrade node, we can release upgrades in isolation to code changes.

Resolves #26. 