### PR TITLE
Group n-heroku-tools and n-gage as "next build tools"

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -59,6 +59,15 @@
       "masterIssueApproval": true
     },
     {
+      "packageNames": [
+        "@financial-times/n-gage",
+        "@financial-times/n-heroku-tools"
+      ],
+      "masterIssueApproval": false,
+      "groupName": "next build tools",
+      "groupSlug": "next-build-tools"
+    },
+    {
       "packagePatterns": [
         "^o-"
       ],


### PR DESCRIPTION
This will get Renovate to open pull requests for major version of @financial-times/n-gage and @financial-times/n-heroku-tools, grouping the changes into a single pull request.

For the current major version, n-gage v3 and n-heroku-tools v8, we should add a comment to the pull requests Renovate opens on app repositories explaining that the app will need to be migrated to the new way of deploying to Heroku.

See https://github.com/Financial-Times/next/wiki/Heroku-review-apps-deployment for more information.

I've opened https://github.com/orgs/Financial-Times/projects/40 as a project board to add the pull requests to.