### PR TITLE
chore: ignore packages publised to bower

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -75,6 +75,10 @@
       "packagePatterns": [
         "^o-"
       ],
+      "packageNames": [
+        "@financial-times/n-profile-ui",
+        "@financial-times/n-live-chat"
+      ],
       "masterIssueApproval": true
     },
     {


### PR DESCRIPTION
We have a handful of packages published to npm and Bower. They need treating like Origami components.

In projects that depend on these packages, we should also not pin to a specific version so that the versions between Bower and npm are the same.