### PR TITLE
feat: update configuration for Page Kit packages

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -92,6 +92,8 @@
       "packagePatterns": [
         "^@financial-times/dotcom-"
       ],
+      "rangeStrategy": "auto",
+      "masterIssueApproval": false,
       "groupName": "page kit monorepo",
       "groupSlug": "page-kit"
     }


### PR DESCRIPTION
This may help with upgrading the dev dependencies of the Page Kit project.

While this is potentially unnecessary, it is more explicit about what we want Renovate to do with these packages.