### PR TITLE
Don't raise patch PRs for internal dependencies

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -32,6 +32,7 @@
   ],
   "packageRules": [
     {
+      "description": "Match our own packages, but only on major or minior versions",
       "packagePatterns": [
         "^@financial-times",
         "^ft-next-",
@@ -48,6 +49,18 @@
       "depTypeList": [
         "dependencies"
       ],
+      "updateTypes": ["major", "minor"],
+      "rangeStrategy": "auto"
+    },
+    {
+      "description": "Match our own packages where patch versions need consistency between apps, like for UI. The last match rule takes precident so this needs to be below our generic internal rule",
+      "packageNames": [
+        "@financial-times/n-myft-ui"
+      ],
+      "depTypeList": [
+        "dependencies"
+      ],
+      "updateTypes": ["major", "minor", "patch"],
       "rangeStrategy": "auto"
     },
     {
@@ -67,6 +80,7 @@
         "@financial-times/n-gage",
         "@financial-times/n-heroku-tools"
       ],
+      "updateTypes": ["major", "minor"],
       "masterIssueApproval": false,
       "groupName": "next build tools",
       "groupSlug": "next-build-tools"


### PR DESCRIPTION
Add an exception in for UI specific repos which we will always want to
merge quickly between systems.

There is a feeling that renovate is opening too many PRs, there isn't
generally a need to keep everything up to date to the nearest patch
level so don't automatically open PRs for patch level releases of
internal packages. This doesn't stop us from manually creating PRs for
those if we do want them.