### PR TITLE
Move renovate activity outside of London working hours to reduce strain on Continuous Integration

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -19,6 +19,7 @@
     "helpers:oddIsUnstablePackages",
     "schedule:nonOfficeHours"
   ],
+  "timezone": "Europe/London",
   "labels": [
     "dependencies"
   ],

--- a/renovate.json
+++ b/renovate.json
@@ -16,7 +16,8 @@
     "group:monorepos",
     "group:recommended",
     "helpers:disableTypesNodeMajor",
-    "helpers:oddIsUnstablePackages"
+    "helpers:oddIsUnstablePackages",
+    "schedule:nonOfficeHours"
   ],
   "labels": [
     "dependencies"

--- a/renovate.json
+++ b/renovate.json
@@ -52,12 +52,6 @@
       "rangeStrategy": "auto"
     },
     {
-      "packageNames": [
-        "@financial-times/n-ui"
-      ],
-      "rangeStrategy": "replace"
-    },
-    {
       "depTypeList": [
         "devDependencies"
       ],


### PR DESCRIPTION
> :wave::skin-tone-2: Hi folks, there’s a small billion (slight emphasis) of renovate n-express builds queued on CircleCI, slowing other builds/PRs getting through. Is there a way these could be applied outside core work hours in future? Thank you :pray::skin-tone-2:

Adds the [`schedule:nonOfficeHours
` preset](https://docs.renovatebot.com/presets-schedule/#schedulenonofficehours) which sets the following:

```json
{
  "schedule": [
    "after 10pm every weekday",
    "before 5am every weekday",
    "every weekend"
  ]
}
```

This will mean dependency updates are only raised out of hours, any important updates in core hours can be forced by [updating the master issue](https://renovate.whitesourcesoftware.com/blog/introducing-renovates-master-issue/).

Also remove the configuration for `n-ui` which should not receive any more updates as it is deprecated, replaced with Page kit.

Closes #41 