### PR TITLE
Bump existing branches outside work hours

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -7,7 +7,6 @@
     ":ignoreUnstable",
     ":prImmediately",
     ":semanticCommitsDisabled",
-    ":updateNotScheduled",
     ":automergeDisabled",
     ":ignoreModulesAndTests",
     ":maintainLockFilesDisabled",
@@ -17,7 +16,8 @@
     "group:recommended",
     "helpers:disableTypesNodeMajor",
     "helpers:oddIsUnstablePackages",
-    "schedule:nonOfficeHours"
+    "schedule:nonOfficeHours",
+    ":noUnscheduledUpdates"
   ],
   "timezone": "Europe/London",
   "labels": [


### PR DESCRIPTION
We are seeing lots of activity from existing branches within work hours, this should mean that updates only happen outside of work hours.

Figured this out by going through the process at https://github.com/renovatebot/config-help which recommended checking the dashboard: https://app.renovatebot.com/dashboard#github/Financial-Times/x-dash/189754427

https://docs.renovatebot.com/presets-default/#updatenotscheduled