### PR TITLE
Allow Renovate to open PRs during office hours

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -16,10 +16,8 @@
     "group:recommended",
     "helpers:disableTypesNodeMajor",
     "helpers:oddIsUnstablePackages",
-    "schedule:nonOfficeHours",
     ":noUnscheduledUpdates"
   ],
-  "timezone": "Europe/London",
   "labels": [
     "dependencies"
   ],


### PR DESCRIPTION
[Jira card CPP-422: Allow Renovate to open PRs in-hours again](https://financialtimes.atlassian.net/secure/RapidBoard.jspa?rapidView=1051&modal=detail&selectedIssue=CPP-422)

> since [CPP-298 (Roll out Renovate/Nori-created PR build pausing to more repos)](https://financialtimes.atlassian.net/browse/CPP-298#icft=CPP-298) was rolled out, Renovate PRs no longer take up slots in the CircleCI queue. allowing Renovate to open PRs in-hours would make it easier for us to update things when we've released a new version of a library without having to wait overnight for Renovate to do its thing or do it manually

This PR is essentially a reversion of this previous PR https://github.com/Financial-Times/renovate-config-next/pull/43.