### PR TITLE
moved supportPolicy inside node config object

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -23,9 +23,9 @@
   "labels": [
     "dependencies"
   ],
-  "supportPolicy": [
-    "lts"
-  ],
+  "node": {
+    "supportPolicy": ["lts"]
+  },
   "branchPrefix": "renovate-",
   "rangeStrategy": "replace",
   "masterIssue": true,


### PR DESCRIPTION
This is a PR to move the supportPolicy inside a node configuration object, as recommended [here](https://docs.renovatebot.com/node/).

All releases are currently raising PRs, so I think this could be a sensible first troubleshooting step.