### PR TITLE
Group updates for advertising monorepo into one PR

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -86,6 +86,13 @@
     },
     {
       "packagePatterns": [
+        "^@financial-times/ads-"
+      ],
+      "groupName": "advertising monorepo",
+      "groupSlug": "advertising"
+    },
+    {
+      "packagePatterns": [
         "^@financial-times/dotcom-"
       ],
       "rangeStrategy": "auto",


### PR DESCRIPTION
Group updates for the [advertising](https://github.com/Financial-Times/advertising) monorepo into a single pull request, similarly to what it's currently done for x-dash and dotcom-page-kit.