### PR TITLE
CPP-422 Allow renovate to open PRs in hours again

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -7,7 +7,6 @@
     ":ignoreUnstable",
     ":prImmediately",
     ":semanticCommitsDisabled",
-    ":updateNotScheduled",
     ":automergeDisabled",
     ":ignoreModulesAndTests",
     ":maintainLockFilesDisabled",
@@ -16,8 +15,7 @@
     "group:monorepos",
     "group:recommended",
     "helpers:disableTypesNodeMajor",
-    "helpers:oddIsUnstablePackages",
-    "schedule:nonOfficeHours"
+    "helpers:oddIsUnstablePackages"
   ],
   "timezone": "Europe/London",
   "labels": [

--- a/renovate.json
+++ b/renovate.json
@@ -7,6 +7,7 @@
     ":ignoreUnstable",
     ":prImmediately",
     ":semanticCommitsDisabled",
+    ":updateNotScheduled",
     ":automergeDisabled",
     ":ignoreModulesAndTests",
     ":maintainLockFilesDisabled",
@@ -16,8 +17,7 @@
     "group:recommended",
     "helpers:disableTypesNodeMajor",
     "helpers:oddIsUnstablePackages",
-    "schedule:nonOfficeHours",
-    ":noUnscheduledUpdates"
+    "schedule:nonOfficeHours"
   ],
   "timezone": "Europe/London",
   "labels": [


### PR DESCRIPTION
When a dependency used by lots of repos is updated, Renovate creates many pull requests, which queue up a lot of builds on CircleCI, blocking other PRs across the entire organisation from building. This also happens when a Nori script applies a change to multiple repos. Before, our solution for this was to have Renovate open PRs out-of-hours, but that caused the queue to clog up for people working on different timezones or on a different work schedule. It also caused the Renovate PR notifications to be more easily missed.

As a solution, we will make Renovate open PRs in-hours again. It would be best if teams in Customer Products modified their CircleCI configuration so that all PRs opened by Renovate and Nori would wait-for-approval to start building so that they experience shorter waiting time on the queue.

More info on the [Have CircleCI wait for approval on Renovate and Nori created PRs Wiki](https://github.com/Financial-Times/next/wiki/Have-CircleCI-wait-for-approval-on-Renovate-and-Nori-created-PRs)