### PR TITLE
add check to ensure file consistency

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "verify": "./scripts/verify.sh",
     "build": "node ./scripts/json5-to-json.js",
-    "test": "renovate-config-validator",
+    "test": "renovate-config-validator && ./scripts/test.sh",
     "preinstall": "[ \"$INIT_CWD\" != \"$PWD\" ] || npm_config_yes=true npx check-engine"
   },
   "license": "MIT",

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+if [[ ! $CI ]]; then
+	exit 0
+fi
+
+mv renovate.json renovateOrig.json
+node scripts/json5-to-json
+
+if cmp -s renovateOrig.json renovate.json;then
+	rm renovateOrig.json
+	echo "renovate.json has been compliled from renovate.json5"
+	exit 0 
+else 
+	mv renovateOrig.json renovate.json
+	echo "renovate.json and renovate.json5 are different, please check that renovate.json is compiled when commiting"
+	exit 1
+fi


### PR DESCRIPTION
currently we have no tests to check that `renovate.json` has been compiled by the most recent `renovate-config.json`, we need to test that this happened on the pre-commit step, and was committed to the repo.