### PR TITLE
Add dotcom-tool-kit and dotcom-reliability-kit monorepos to config

### DIFF
--- a/renovate-config.json5
+++ b/renovate-config.json5
@@ -124,6 +124,16 @@
       groupName: 'Tool Kit monorepo',
       groupSlug: 'dotcom-tool-kit',
     },
+    {
+      // group Reliability Kit packages together
+      matchPackagePrefixes: [
+        '@dotcom-reliability-kit/',
+      ],
+      rangeStrategy: 'auto',
+      dependencyDashboardApproval: false,
+      groupName: 'Reliability Kit monorepo',
+      groupSlug: 'dotcom-reliability-kit',
+    },
   ],
   ignoreDeps: [
     'bower',

--- a/renovate-config.json5
+++ b/renovate-config.json5
@@ -114,6 +114,16 @@
       groupName: 'page kit monorepo',
       groupSlug: 'page-kit',
     },
+    {
+      // group Tool Kit packages together
+      matchPackagePrefixes: [
+        '@dotcom-tool-kit/',
+      ],
+      rangeStrategy: 'auto',
+      dependencyDashboardApproval: false,
+      groupName: 'Tool Kit monorepo',
+      groupSlug: 'dotcom-tool-kit',
+    },
   ],
   ignoreDeps: [
     'bower',

--- a/renovate.json
+++ b/renovate.json
@@ -114,6 +114,15 @@
    "dependencyDashboardApproval": false,
    "groupName": "Tool Kit monorepo",
    "groupSlug": "dotcom-tool-kit"
+  },
+  {
+   "matchPackagePrefixes": [
+    "@dotcom-reliability-kit/"
+   ],
+   "rangeStrategy": "auto",
+   "dependencyDashboardApproval": false,
+   "groupName": "Reliability Kit monorepo",
+   "groupSlug": "dotcom-reliability-kit"
   }
  ],
  "ignoreDeps": [

--- a/renovate.json
+++ b/renovate.json
@@ -105,6 +105,15 @@
    "dependencyDashboardApproval": false,
    "groupName": "page kit monorepo",
    "groupSlug": "page-kit"
+  },
+  {
+   "matchPackagePrefixes": [
+    "@dotcom-tool-kit/"
+   ],
+   "rangeStrategy": "auto",
+   "dependencyDashboardApproval": false,
+   "groupName": "Tool Kit monorepo",
+   "groupSlug": "dotcom-tool-kit"
   }
  ],
  "ignoreDeps": [


### PR DESCRIPTION
Adding our https://github.com/Financial-Times/dotcom-tool-kit and https://github.com/Financial-Times/dotcom-reliability-kit monorepos to the config.