### PR TITLE
CPP-1375: add changes from renovate-config-next-beta

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,17 +9,21 @@ We have a custom set of rules for FT.com repositories. We are generally...
 
 * Letting Renovate decide how to [modify or update existing ranges](https://renovatebot.com/docs/configuration-options/#rangestrategy) on Financial Times owned `dependencies`
 
-  * For apps this means pinning to specific versions for reliability/predictability e.g. `@financial-times/n-express@19.19.1`, with pull requests being opened for any new version
-
-  * For components this means using semver ranges e.g. `@financial-times/n-fetch@^1.0.0`, only opening pull requests for major version updates
-
 * Using semver ranges for all other `dependencies` (including [`n-ui`](https://github.com/Financial-Times/n-ui)), only opening pull requests for major version updates
 
-* Grouping updates for our monorepos (such as [x-dash](https://github.com/Financial-Times/x-dash) and [Page Kit](https://github.com/Financial-Times/dotcom-page-kit)) into a single pull request
+* Grouping updates for the following monorepos into a single pull request
+  * [x-dash](https://github.com/Financial-Times/x-dash)
+  * [Page Kit](https://github.com/Financial-Times/dotcom-page-kit)
+  * [Tool Kit](https://github.com/Financial-Times/dotcom-tool-kit)
+  * [Reliability Kit](https://github.com/Financial-Times/dotcom-reliability-kit)
+  * [Ads](https://github.com/Financial-Times/ads)
+  * [Privacy](https://github.com/Financial-Times/privacy)
 
 * [Upgrading Node.js to LTS versions](https://renovatebot.com/docs/node/#configuring-support-policy), including any under their maintenance period.
 
 * Tracking major updates of `devDependencies` and [Origami](https://registry.origami.ft.com/components) components (`o-*` packages) in the Renovate master issue, but **we're not** opening pull requests automatically for them
+
+* All external dependencies updates will be managed in the [Dependency Dashboard](https://docs.renovatebot.com/configuration-options/#dependencydashboard)
 
 Read more about [how we're using Renovate on its wiki page](https://github.com/Financial-Times/next/wiki/Renovate).
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 [![CircleCI](https://circleci.com/gh/Financial-Times/renovate-config-next.svg?style=svg)](https://circleci.com/gh/Financial-Times/renovate-config-next)
 
 > Shared [Renovate](https://renovatebot.com/) configuration for FT.com.
-
 ## Our Configuration
 
 We have a custom set of rules for FT.com repositories. We are generally...

--- a/renovate-config.json5
+++ b/renovate-config.json5
@@ -2,7 +2,6 @@
   // this file gets transpiled to a renovate.json file on a pre-commit hook, do not edit renovate.json directly.
   extends: [
     ':npm',
-    ':docker',
     ':separateMajorReleases',
     ':combinePatchMinorReleases',
     ':ignoreUnstable',
@@ -23,6 +22,7 @@
   branchPrefix: 'renovate-',
   rangeStrategy: 'replace', // replace the version range with new one if new version is outside old range in package.json
   dependencyDashboard: true,
+  dependencyDashboardApproval: true, // prevent Renovate opening PRs for most things without a manual step
   prBodyNotes: [
     ':information_source: Find our documentation at https://github.com/Financial-Times/next/wiki/Renovate.',
   ],
@@ -31,20 +31,19 @@
       matchPackagePrefixes: [
         '@financial-times',
         'ft-next-',
-        'ft-n-',
-        'n-',
-        'next-',
-        's3o-',
+        'ft-n-'
       ],
       matchPackageNames: [
         'shellpromise',
         'fetchres',
         'isomorphic-fetch',
+        'next-metrics',
+        'n-health'
       ],
       depTypeList: [
         'dependencies',
       ],
-      rangeStrategy: 'auto',
+      dependencyDashboardApproval: false, // override default and open PRs for internal packages + the ones stated
     },
     {
       // for devDependencies, don't create a PR until the checkbox is checked on the "dependency issue"

--- a/renovate-config.json5
+++ b/renovate-config.json5
@@ -28,7 +28,6 @@
   ],
   packageRules: [
     {
-      // enables range strategy auto (pin dependencies if it's an app and not a library) for internal packages + the ones stated
       matchPackagePrefixes: [
         '@financial-times',
         'ft-next-',

--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,6 @@
 {
  "extends": [
   ":npm",
-  ":docker",
   ":separateMajorReleases",
   ":combinePatchMinorReleases",
   ":ignoreUnstable",
@@ -22,6 +21,7 @@
  "branchPrefix": "renovate-",
  "rangeStrategy": "replace",
  "dependencyDashboard": true,
+ "dependencyDashboardApproval": true,
  "prBodyNotes": [
   ":information_source: Find our documentation at https://github.com/Financial-Times/next/wiki/Renovate."
  ],
@@ -30,20 +30,19 @@
    "matchPackagePrefixes": [
     "@financial-times",
     "ft-next-",
-    "ft-n-",
-    "n-",
-    "next-",
-    "s3o-"
+    "ft-n-"
    ],
    "matchPackageNames": [
     "shellpromise",
     "fetchres",
-    "isomorphic-fetch"
+    "isomorphic-fetch",
+    "next-metrics",
+    "n-health"
    ],
    "depTypeList": [
     "dependencies"
    ],
-   "rangeStrategy": "auto"
+   "dependencyDashboardApproval": false
   },
   {
    "depTypeList": [


### PR DESCRIPTION
Add the commits for the changes that were in Financial-Times/renovate-config-next-beta#1.