### PR TITLE
Update to Node 18

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,11 +9,9 @@ jobs:
       - image: cimg/node:<< parameters.node-version >>
     steps:
       - checkout
-      - node/install-npm:
-          version: "7"
       - run: npm install
       - run: npm test
     parameters:
       node-version:
-        default: "16.14"
+        default: "18.16"
         type: string

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,8 +5,8 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "renovate-config-next",
       "version": "0.0.0",
-      "hasInstallScript": true,
       "license": "MIT",
       "devDependencies": {
         "check-engine": "^1.10.1",
@@ -15,8 +15,8 @@
         "renovate": "^25.59.1"
       },
       "engines": {
-        "node": "16.x",
-        "npm": "7.x || 8.x"
+        "node": "16.x || 18.x",
+        "npm": "7.x || 8.x || 9.x"
       }
     },
     "node_modules/@arcanis/slice-ansi": {

--- a/package.json
+++ b/package.json
@@ -6,8 +6,7 @@
   "scripts": {
     "verify": "./scripts/verify.sh",
     "build": "node ./scripts/json5-to-json.js",
-    "test": "renovate-config-validator && ./scripts/test.sh",
-    "preinstall": "[ \"$INIT_CWD\" != \"$PWD\" ] || npm_config_yes=true npx check-engine"
+    "test": "renovate-config-validator && ./scripts/test.sh"
   },
   "license": "MIT",
   "devDependencies": {
@@ -22,11 +21,10 @@
     }
   },
   "volta": {
-    "node": "16.14.0",
-    "npm": "7.20.2"
+    "node": "18.16.0"
   },
   "engines": {
-    "node": "16.x",
-    "npm": "7.x || 8.x"
+    "node": "16.x || 18.x",
+    "npm": "7.x || 8.x || 9.x"
   }
 }


### PR DESCRIPTION
Automatically ran via Platforms' [migration script](https://github.com/Financial-Times/platform-scripts/blob/464d56876a27742dbdee2713a31266cc268ebfe3/upgrade-node-18/upgrade-node-18.ts)